### PR TITLE
fixed calculating colSpan. based on reactabular issue #301.

### DIFF
--- a/__tests__/header-rows-test.js
+++ b/__tests__/header-rows-test.js
@@ -131,10 +131,15 @@ describe('resolveHeaderRows', function () {
     expect(resolveHeaderRows({ columns })).toEqual(expected);
   });
 
-  it('calculates rowSpan based on siblings', function () {
+  it('calculates colSpan and rowSpan based on siblings ang children', function () {
     const basicColumn = {
       header: {
         label: 'foo'
+      }
+    };
+    const thirdColumn = {
+      header: {
+        label: 'boo'
       }
     };
     const column = {
@@ -143,7 +148,13 @@ describe('resolveHeaderRows', function () {
       },
       children: [
         basicColumn,
-        basicColumn
+        {
+          ...thirdColumn,
+          children: [
+            basicColumn,
+            thirdColumn
+          ]
+        }
       ]
     };
     const columns = [basicColumn, column];
@@ -152,13 +163,27 @@ describe('resolveHeaderRows', function () {
         {
           ...basicColumn,
           props: {
-            rowSpan: 2
+            rowSpan: 3
           }
         },
         {
           header: {
             label: 'bar'
           },
+          props: {
+            colSpan: 3
+          }
+        }
+      ],
+      [
+        {
+          ...basicColumn,
+          props: {
+            rowSpan: 2
+          }
+        },
+        {
+          ...thirdColumn,
           props: {
             colSpan: 2
           }
@@ -172,7 +197,7 @@ describe('resolveHeaderRows', function () {
           }
         },
         {
-          ...basicColumn,
+          ...thirdColumn,
           props: {
             rowSpan: 1
           }

--- a/src/count-col-span.js
+++ b/src/count-col-span.js
@@ -1,0 +1,15 @@
+function countColSpan(columns, returnCount) {
+  let count = returnCount;
+  if (columns && columns.length > 0) {
+    columns.forEach((column) => {
+      if (column.children && column.children.length > 0) {
+        count = countColSpan(column.children, count);
+      } else {
+        count += 1;
+      }
+    });
+  }
+  return count;
+}
+
+export default countColSpan;

--- a/src/header-rows.js
+++ b/src/header-rows.js
@@ -1,43 +1,37 @@
 import { omit } from 'lodash';
 import countRowSpan from './count-row-span';
+import countColSpan from './count-col-span';
 
 function resolveHeaderRows({
   columns,
   childrenField = 'children'
 }) {
-  let resolvedChildren = [];
+  const resolvedChildren = [];
 
   const ret = columns.map((column) => {
     const children = column[childrenField];
     const col = omit(column, [childrenField]);
 
     if (children && children.length) {
-      resolvedChildren = resolvedChildren.concat(
-        resolveHeaderRows({
-          columns: children,
-          childrenField
-        })[0]
-      );
+      resolveHeaderRows({ columns: children, childrenField }).forEach((cells, depth) => {
+        resolvedChildren[depth] = [...(resolvedChildren[depth] || []), ...cells];
+      });
 
-      return {
-        ...col,
-        props: {
-          colSpan: children.length,
-          ...col.props
-        }
-      };
+      return Object.assign({}, col, {
+        props: Object.assign({
+          colSpan: countColSpan(children, 0)
+        }, col.props)
+      });
     }
 
-    return {
-      ...col,
-      props: {
-        rowSpan: countRowSpan(columns),
-        ...col.props
-      }
-    };
+    return Object.assign({}, col, {
+      props: Object.assign({
+        rowSpan: countRowSpan(columns)
+      }, col.props)
+    });
   });
 
-  return resolvedChildren.length ? [ret].concat([resolvedChildren]) : [ret];
+  return resolvedChildren.length ? [ret].concat(resolvedChildren) : [ret];
 }
 
 export default resolveHeaderRows;


### PR DESCRIPTION
1 month ago, I wrote a [issue](https://github.com/reactabular/reactabular/issues/301) on reactabular repository. 

When resolving header columns, this problem occur.  some columns children having just one depth is pass without any problems. but more then two depth children can't calculate colSpan correctly. 

I fixed this problem, making new calculating colSpan function.

Please accept my pull request. Thanks.