### PR TITLE
Improve performance for large data sets

### DIFF
--- a/src/by-function.js
+++ b/src/by-function.js
@@ -3,24 +3,22 @@ import { get } from 'lodash';
 function byFunction(path) {
   return ({ column = {} }) => (rowData) => {
     const { property } = column;
+    const resolver = get(column, path);
 
-    if (!property) {
+    if (!property || !resolver) {
       return rowData;
     }
 
     const value = rowData[property];
-    const resolver = get(column, path);
     const ret = {
       ...rowData,
       [property]: value
     };
 
-    if (resolver) {
-      ret[`_${property}`] = resolver(value, {
-        property,
-        rowData
-      });
-    }
+    ret[`_${property}`] = resolver(value, {
+      property,
+      rowData
+    });
 
     return ret;
   };

--- a/src/nested.js
+++ b/src/nested.js
@@ -1,22 +1,29 @@
 import { get, has, isFunction } from 'lodash';
 
+const reIsPlainProp = /^\w*$/;
+
 function nested({ column }) {
+  const { property } = column;
+
+  if (!property) {
+    return () => ({});
+  }
+
+  // if users provide a custom getter instead of a
+  // path for _.get, use that getter ...
+  if (isFunction(property)) {
+    return rowData => ({
+      ...rowData,
+      [property]: property(rowData)
+    });
+  }
+
+  // Make things simple if the property is simple.  No copy needed.
+  if (typeof property === 'string' && reIsPlainProp.test(property)) {
+    return rowData => rowData;
+  }
+
   return (rowData) => {
-    const { property } = column;
-
-    if (!property) {
-      return {};
-    }
-
-    // if users provide a custom getter instead of a
-    // path for _.get, use that getter ...
-    if (isFunction(property)) {
-      return {
-        ...rowData,
-        [property]: property(rowData)
-      };
-    }
-
     // ... otherwise, make sure property exists, then _.get it
     if (!has(rowData, property)) {
       return {};

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -11,7 +11,10 @@ function resolve({
     const methodsByColumnIndex = columns.map(column => method({ column }));
 
     return rows.map((rowData, rowIndex) => {
-      let ret = {};
+      let ret = {
+        [indexKey]: rowIndex,
+        ...rowData
+      };
 
       columns.forEach((column, columnIndex) => {
         const result = methodsByColumnIndex[columnIndex](rowData);
@@ -19,8 +22,6 @@ function resolve({
         delete result.undefined;
 
         ret = {
-          [indexKey]: rowIndex,
-          ...rowData,
           ...ret,
           ...result
         };


### PR DESCRIPTION
When using table-resolver on a large data set (~5000 rows of data, weighing in about 25MB represented as JSON), performance can be quite bad.

This pull's improvement can vary, but these changes improve my usage on this data set by 36% - from 3.67s average to 2.35s.

None of these changes should alter the API in a real observable way, although some semantics of property lookups are different (so complex scenarios involving getters might observe changes.)

I will note: most of the time is still spent cloning data unnecessarily.  Reducing the clones to once per row could reduce time on top of this pull by about 90%, down to 0.21s.  However, this would definitely change the exposed API - semantics of overlapping columns would change, and using nested/etc. directly without resolve would alter input arguments.