### PR TITLE
Improve performance significantly for large data sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ The `resolve` iterator automatically injects into every resolved row object a fi
 
 If your own resolver (e.g. `byFunction`) happens to also output a field named `_index`, it will overwrite the default one. In that case, if you still need the row index, you may wish to pass a different `indexKey` when calling `resolve`.
 
+Note that columns are resolved in order.  This means the `rowData` passed into a custom resolver will contain properties from earlier columns.
+
 ### Method `resolve.nested`
 
 **`({ column }) => (rowData) => <resolved row>`**
 
 The `nested` resolver digs rows from a `property: 'name.first'` kind of definition and maps the received value to property name. It replaces the original value with the resolved one. *Note*: instead of defining a path string `property: 'name.first'`, you may provide a custom getter function `property: data => (data.name || {}).first` directly. This may be slightly faster but needs to be done carefully to prevent TypeErrors due to missing values.
+
+This is not intended to be called directly.  Pass it as a method to `resolve.resolve()`.
 
 ### Method creator `resolve.byFunction`
 
@@ -43,6 +47,8 @@ The `nested` resolver digs rows from a `property: 'name.first'` kind of definiti
 The `byFunction` resolver accepts a path from where to look for a resolving function. It could be `column.cell.resolve` for example and you can use a nested definition for getting it from your column definition.
 
 Instead of replacing the original value, `byFunction` generates `_<property>` kind of field to the resulting rows. This sort of implicit rule is useful for other functionality as it can rely on the same convention.
+
+This is not intended to be called directly.  Pass it as a method to `resolve.resolve()`.
 
 ## Column Resolvers
 

--- a/__tests__/nested-test.js
+++ b/__tests__/nested-test.js
@@ -45,6 +45,17 @@ describe('resolve.nested', function () {
     expect(nested({ column })(rowData)).toEqual({ [property]: name });
   });
 
+  it('does not crash when row is missing property', function () {
+    const name = 'demo';
+    const property = 'other.name';
+    const rowData = {
+      name
+    };
+    const column = { property };
+
+    expect(nested({ column })(rowData)).toEqual(rowData);
+  });
+
   it('does nothing if there is no property', function () {
     const name = 'demo';
     const rowData = {

--- a/__tests__/nested-test.js
+++ b/__tests__/nested-test.js
@@ -52,7 +52,7 @@ describe('resolve.nested', function () {
     };
     const column = { property: undefined };
 
-    expect(nested({ column })(rowData)).toEqual({});
+    expect(nested({ column })(rowData)).toEqual(rowData);
   });
 
   it('does not crash without a property', function () {
@@ -62,7 +62,7 @@ describe('resolve.nested', function () {
     };
     const column = { cell: {} };
 
-    expect(nested({ column })(rowData)).toEqual({});
+    expect(nested({ column })(rowData)).toEqual(rowData);
   });
 
   it('does not crash without a cell', function () {
@@ -72,6 +72,6 @@ describe('resolve.nested', function () {
     };
     const column = {};
 
-    expect(nested({ column })(rowData)).toEqual({});
+    expect(nested({ column })(rowData)).toEqual(rowData);
   });
 });

--- a/__tests__/resolve-test.js
+++ b/__tests__/resolve-test.js
@@ -80,6 +80,7 @@ describe('resolve.resolve', function () {
       }
     ];
     const method = ({ column }) => rowData => ({
+      ...rowData,
       [column.property]: rowData.name,
       [`_${column.property}`]: rowData.name
     });

--- a/__tests__/resolve-test.js
+++ b/__tests__/resolve-test.js
@@ -295,4 +295,18 @@ describe('resolve.resolve', function () {
 
     expect(resolver()).toEqual([]);
   });
+
+  it('crashes without columns', function () {
+    const rows = [
+      {
+        id: 123
+      }
+    ];
+    const perform = () => {
+      const resolver = resolve({ rows });
+      return resolver()
+    };
+
+    expect(perform).toThrow();
+  });
 });

--- a/src/by-function.js
+++ b/src/by-function.js
@@ -1,6 +1,8 @@
 import { get } from 'lodash';
 
 function byFunction(path) {
+  /* eslint no-param-reassign: "off" */
+
   return ({ column = {} }) => (rowData) => {
     const { property } = column;
     const resolver = get(column, path);
@@ -10,17 +12,13 @@ function byFunction(path) {
     }
 
     const value = rowData[property];
-    const ret = {
-      ...rowData,
-      [property]: value
-    };
 
-    ret[`_${property}`] = resolver(value, {
+    rowData[`_${property}`] = resolver(value, {
       property,
       rowData
     });
 
-    return ret;
+    return rowData;
   };
 }
 

--- a/src/nested.js
+++ b/src/nested.js
@@ -6,12 +6,13 @@ function nested({ column }) {
   const { property } = column;
 
   if (!property) {
-    return () => ({});
+    return rowData => rowData;
   }
 
   // if users provide a custom getter instead of a
   // path for _.get, use that getter ...
   if (isFunction(property)) {
+    // TODO: Function as key can't be right?
     return rowData => ({
       ...rowData,
       [property]: property(rowData)
@@ -26,7 +27,7 @@ function nested({ column }) {
   return (rowData) => {
     // ... otherwise, make sure property exists, then _.get it
     if (!has(rowData, property)) {
-      return {};
+      return rowData;
     }
 
     return {

--- a/src/nested.js
+++ b/src/nested.js
@@ -3,6 +3,8 @@ import { get, has, isFunction } from 'lodash';
 const reIsPlainProp = /^\w*$/;
 
 function nested({ column }) {
+  /* eslint no-param-reassign: "off" */
+
   const { property } = column;
 
   if (!property) {
@@ -13,10 +15,10 @@ function nested({ column }) {
   // path for _.get, use that getter ...
   if (isFunction(property)) {
     // TODO: Function as key can't be right?
-    return rowData => ({
-      ...rowData,
-      [property]: property(rowData)
-    });
+    return (rowData) => {
+      rowData[property] = property(rowData);
+      return rowData;
+    };
   }
 
   // Make things simple if the property is simple.  No copy needed.
@@ -30,10 +32,8 @@ function nested({ column }) {
       return rowData;
     }
 
-    return {
-      ...rowData,
-      [property]: get(rowData, property)
-    };
+    rowData[property] = get(rowData, property);
+    return rowData;
   };
 }
 

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -20,8 +20,6 @@ function resolve({
         ret = boundMethod(ret);
       });
 
-      // TODO: What's the purpose of this?
-      delete ret.undefined;
       return ret;
     });
   };

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -8,7 +8,7 @@ function resolve({
   }
 
   return (rows = []) => {
-    const methodsByColumnIndex = columns.map(column => method({ column }));
+    const methodsByColumn = columns.map(column => method({ column }));
 
     return rows.map((rowData, rowIndex) => {
       let ret = {
@@ -16,17 +16,12 @@ function resolve({
         ...rowData
       };
 
-      columns.forEach((column, columnIndex) => {
-        const result = methodsByColumnIndex[columnIndex](rowData);
-
-        delete result.undefined;
-
-        ret = {
-          ...ret,
-          ...result
-        };
+      methodsByColumn.forEach((boundMethod) => {
+        ret = boundMethod(ret);
       });
 
+      // TODO: What's the purpose of this?
+      delete ret.undefined;
       return ret;
     });
   };


### PR DESCRIPTION
This reduces time taken with large data sets significantly (90% or better), by eliminating most cloning.  Each row of the original data will now be cloned only once through the `resolve()` function.

This has many semantic differences from the previous behavior:

 * Methods must now return a full row - either directly modifying their input, or a complete clone of the input.  A partial result is no longer merged into the original row.
 * If methods generate a property literally named 'undefined', it will no longer be discarded.
 * If nested or byFunction are called directly, they will now modify the input object (their argument) and return that same object.
 * Methods will be exposed to the results of other columns.  For example, if byFunction is used to replace a country object with a string, but another column uses 'country.code', the order of columns will now matter.  Avoid this by using a different column name, such as 'country.name'.

If you call resolve() with byFunction() and nested() without any overlapping column names, everything should continue to work with only improved performance.